### PR TITLE
Checking for fewer than two data points in C2CubicSpline 

### DIFF
--- a/ecl_geometry/src/lib/cubic_spline_blueprints.cpp
+++ b/ecl_geometry/src/lib/cubic_spline_blueprints.cpp
@@ -44,7 +44,7 @@ C2CubicSpline::C2CubicSpline(const ecl::Array<double>& x_set, const ecl::Array<d
                                     x_data(x_set),
                                     y_data(y_set)
 {
-    if (x_data.size() < 2)
+    if (x_data.size() < 2 || y_data.size() < 2)
     {
       ecl_throw(StandardException(LOC,OutOfRangeError) );
     }
@@ -84,7 +84,7 @@ C2CubicSpline::C2CubicSpline(const ecl::Array<double>& x_set, const ecl::Array<d
                                     x_data(x_set),
                                     y_data(y_set)
 {
-    if (x_data.size() < 2)
+    if (x_data.size() < 2 || y_data.size() < 2)
     {
       ecl_throw(StandardException(LOC,OutOfRangeError) );
     }

--- a/ecl_geometry/src/lib/cubic_spline_blueprints.cpp
+++ b/ecl_geometry/src/lib/cubic_spline_blueprints.cpp
@@ -44,6 +44,10 @@ C2CubicSpline::C2CubicSpline(const ecl::Array<double>& x_set, const ecl::Array<d
                                     x_data(x_set),
                                     y_data(y_set)
 {
+    if (x_data.size() < 2)
+    {
+      ecl_throw(StandardException(LOC,OutOfRangeError) );
+    }
     ecl_assert_throw( x_data.size() == y_data.size(), StandardException(LOC,OutOfRangeError) );
     unsigned int n = x_data.size();
     yddot_data.resize(n);
@@ -80,6 +84,10 @@ C2CubicSpline::C2CubicSpline(const ecl::Array<double>& x_set, const ecl::Array<d
                                     x_data(x_set),
                                     y_data(y_set)
 {
+    if (x_data.size() < 2)
+    {
+      ecl_throw(StandardException(LOC,OutOfRangeError) );
+    }
     ecl_assert_throw( x_data.size() == y_data.size(), StandardException(LOC,OutOfRangeError) );
     unsigned int n = x_data.size();
     yddot_data.resize(n);


### PR DESCRIPTION
I found that these methods would seg fault if x contained only a single point. This was due to the logic that uses the index n-2 for the u array whose length is the same as the input data. The ecl_assert_throw macro doesn't function in release mode, so I added a manual check for this condition.
