### PR TITLE
Properly guard catkin_add_gtest.

### DIFF
--- a/ecl_mpl/src/test/CMakeLists.txt
+++ b/ecl_mpl/src/test/CMakeLists.txt
@@ -2,4 +2,6 @@
 # Gtests
 ###############################################################################
 
-catkin_add_gtest(test_enable_if enable_if.cpp)
+if(CATKIN_ENABLE_TESTING)
+  catkin_add_gtest(test_enable_if enable_if.cpp)
+endif()


### PR DESCRIPTION
This is just a single instance; if you're interested in fixing this up, I can see about taking care of a bunch more of them.
