### PR TITLE
Various compile fixes for OSX

### DIFF
--- a/ecl_devices/src/lib/serial_pos.cpp
+++ b/ecl_devices/src/lib/serial_pos.cpp
@@ -17,6 +17,7 @@
  ** Includes
  *****************************************************************************/
 
+#include <errno.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <termios.h>
@@ -37,6 +38,9 @@
 // FreeBSD has had it for at least four years and linux quite some time too.
 // Apple Macs however do not currently have it, so we help it here.
 #if defined(ECL_IS_APPLE)
+  #ifndef B460800
+    #define B460800 460800
+  #endif
   #ifndef B921600
     #define B921600 921600
   #endif

--- a/ecl_ipc/include/ecl/ipc/shared_memory_pos.hpp
+++ b/ecl_ipc/include/ecl/ipc/shared_memory_pos.hpp
@@ -21,7 +21,9 @@
 #include <ecl/config.hpp>
 #if defined(ECL_IS_POSIX)
 #include <unistd.h>
+#if !defined(ECL_IS_APPLE)
 #include <bits/posix_opt.h>
+#endif
 #ifdef _POSIX_SHARED_MEMORY_OBJECTS
 #if _POSIX_SHARED_MEMORY_OBJECTS > 0
 

--- a/ecl_time/src/lib/frequency.cpp
+++ b/ecl_time/src/lib/frequency.cpp
@@ -28,14 +28,22 @@ FrequencyMonitor::FrequencyMonitor(
 , maximum_interval(0.0)
 , period(window_period)
 , use_realtime_clock(use_realtime_clock)
+#if defined(ECL_HAS_RT_TIMERS)
 , last_incoming((use_realtime_clock) ? ecl::TimeStamp::realtime_now() : ecl::TimeStamp())
+#else
+, last_incoming(ecl::TimeStamp())
+#endif
 {
 }
 
 void FrequencyMonitor::update() {
   current_diagnostics.has_connection = true;
   incoming_counter++;
+#if defined(ECL_HAS_RT_TIMERS)
   ecl::TimeStamp new_incoming = (use_realtime_clock) ? ecl::TimeStamp::realtime_now() : ecl::TimeStamp();
+#else
+  ecl::TimeStamp new_incoming = ecl::TimeStamp();
+#endif
   ecl::TimeStamp time_since_last = new_incoming - last_incoming;
   if ( time_since_last < minimum_interval ) {
     minimum_interval = time_since_last;
@@ -47,7 +55,11 @@ void FrequencyMonitor::update() {
 }
 
 const FrequencyDiagnostics& FrequencyMonitor::analyse() {
+#if defined(ECL_HAS_RT_TIMERS)
   ecl::TimeStamp now = ecl::TimeStamp::realtime_now();
+#else
+  ecl::TimeStamp now = ecl::TimeStamp();
+#endif 
   ecl::TimeStamp interval = now - last_anyalsed;
 
   /// every two seconds, we update the status as follows


### PR DESCRIPTION
In addition to these fixes, I had to `CATKIN_IGNORE` the following packages to get everything else up through kobuki_core to build:
- ~~ecl_streams~~ (got that one working; not sure what the problem was)
- ecl_core_apps
- ~~kobuki_ftdi (not in this repo, I know)~~ (got that working by brew installing `libusb-compat` and `libfdti0`)
