### PR TITLE
[ecl_containers] Fix gcc v7.1 compilation issue

### DIFF
--- a/ecl_containers/include/ecl/containers/common/formatters.hpp
+++ b/ecl_containers/include/ecl/containers/common/formatters.hpp
@@ -123,7 +123,7 @@ class ECL_LOCAL FloatContainerFormatter {
          * @param w : the width to use for the inserted float.
          * @return FloatContainerFormatter& : this formatter readied for use with a stream.
          */
-        FloatContainerFormatter& operator()(const unsigned int p, const int w) { format.precision(p); prm_width(w); return *this; } // Permanent
+        FloatContainerFormatter& operator()(const unsigned int p, const int w) { format.precision(p); prm_width = w; return *this; } // Permanent
         /**
          * Convenient stream formatter. This function directly readies the formatter
          * with the specified container and the stored (permanent) settings.


### PR DESCRIPTION
When built with gcc v7.1 compilation fails with an error message
about using an expression as a function when updating
the private attribute FloatContainerFormatter.prm_width.

The patch uses assignment to update the attribute.