### PR TITLE
Make ecl_converters link against ecl_exceptions.

### DIFF
--- a/ecl_converters/CMakeLists.txt
+++ b/ecl_converters/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(
     ecl_concepts::ecl_concepts
     ecl_config::ecl_config
     ecl_errors::ecl_errors
+    ecl_exceptions::ecl_exceptions
     ecl_mpl::ecl_mpl
     ecl_type_traits::ecl_type_traits
 )


### PR DESCRIPTION
Otherwise the demos fail to link.

In particular, we see:

```
CMakeFiles/demo_float_converters.dir/float_converters.cpp.o: In function `ecl::StandardException::~StandardException()':
float_converters.cpp:(.text._ZN3ecl17StandardExceptionD2Ev[_ZN3ecl17StandardExceptionD5Ev]+0xd): undefined reference to `vtable for ecl::StandardException'
CMakeFiles/demo_float_converters.dir/float_converters.cpp.o: In function `ecl::converters::CharStringBuffer::CharStringBuffer(int)':
float_converters.cpp:(.text._ZN3ecl10converters16CharStringBufferC2Ei[_ZN3ecl10converters16CharStringBufferC5Ei]+0xd3): undefined reference to `ecl::StandardException::StandardException(char const*, ecl::ErrorFlag, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
float_converters.cpp:(.text._ZN3ecl10converters16CharStringBufferC2Ei[_ZN3ecl10converters16CharStringBufferC5Ei]+0xf5): undefined reference to `typeinfo for ecl::StandardException'
CMakeFiles/demo_float_converters.dir/float_converters.cpp.o:(.gcc_except_table._ZN3ecl10converters16CharStringBufferC2Ei[_ZN3ecl10converters16CharStringBufferC5Ei]+0x20): undefined reference to `typeinfo for ecl::StandardException'
CMakeFiles/demo_float_converters.dir/float_converters.cpp.o:(.gcc_except_table._ZN3ecl9ConverterIPciEC1Ei[_ZN3ecl9ConverterIPciEC1Ei]+0x10): undefined reference to `typeinfo for ecl::StandardException'
CMakeFiles/demo_float_converters.dir/float_converters.cpp.o:(.gcc_except_table._ZN3ecl9ConverterIPcfEC1Ei[_ZN3ecl9ConverterIPcfEC1Ei]+0x10): undefined reference to `typeinfo for ecl::StandardException'
CMakeFiles/demo_float_converters.dir/float_converters.cpp.o:(.gcc_except_table._ZN3ecl9ConverterIPcdEC1Ei[_ZN3ecl9ConverterIPcdEC1Ei]+0x10): undefined reference to `typeinfo for ecl::StandardException'
collect2: error: ld returned 1 exit status
src/examples/CMakeFiles/demo_float_converters.dir/build.make:96: recipe for target 'src/examples/demo_float_converters' failed
make[2]: *** [src/examples/demo_float_converters] Error 1
CMakeFiles/Makefile2:189: recipe for target 'src/examples/CMakeFiles/demo_float_converters.dir/all' failed
make[1]: *** [src/examples/CMakeFiles/demo_float_converters.dir/all] Error 2
Makefile:127: recipe for target 'all' failed
make: *** [all] Error 2
```

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>