### PR TITLE
Make sure to ament_export_libraries.

### DIFF
--- a/ecl_devices/CMakeLists.txt
+++ b/ecl_devices/CMakeLists.txt
@@ -47,4 +47,5 @@ ament_export_dependencies(
     ecl_type_traits
     ecl_utilities
 )
+ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_exceptions/CMakeLists.txt
+++ b/ecl_exceptions/CMakeLists.txt
@@ -37,4 +37,5 @@ ament_export_dependencies(
     ecl_config
     ecl_errors
 )
+ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_filesystem/CMakeLists.txt
+++ b/ecl_filesystem/CMakeLists.txt
@@ -47,4 +47,5 @@ ament_export_dependencies(
     ecl_config
     ecl_errors
 )
+ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_formatters/CMakeLists.txt
+++ b/ecl_formatters/CMakeLists.txt
@@ -39,4 +39,5 @@ ament_export_dependencies(
     ecl_converters
     ecl_exceptions
 )
+ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_geometry/CMakeLists.txt
+++ b/ecl_geometry/CMakeLists.txt
@@ -49,4 +49,5 @@ ament_export_dependencies(
     ecl_mpl
     ecl_type_traits
 )
+ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_ipc/CMakeLists.txt
+++ b/ecl_ipc/CMakeLists.txt
@@ -46,6 +46,5 @@ ament_export_dependencies(
     ecl_time_lite
     ecl_time
 )
+ament_export_libraries(${PROJECT_NAME})
 ament_package()
-
-

--- a/ecl_linear_algebra/CMakeLists.txt
+++ b/ecl_linear_algebra/CMakeLists.txt
@@ -44,4 +44,5 @@ ament_export_dependencies(
     ecl_math
     Sophus
 )
+ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_statistics/CMakeLists.txt
+++ b/ecl_statistics/CMakeLists.txt
@@ -41,4 +41,5 @@ ament_export_dependencies(
     ecl_mpl
     ecl_type_traits
 )
+ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_streams/CMakeLists.txt
+++ b/ecl_streams/CMakeLists.txt
@@ -46,4 +46,5 @@ ament_export_dependencies(
     ecl_time
     ecl_type_traits
 )
+ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_threads/CMakeLists.txt
+++ b/ecl_threads/CMakeLists.txt
@@ -55,4 +55,5 @@ ament_export_dependencies(
     ecl_time
     ecl_utilities
 )
+ament_export_libraries(${PROJECT_NAME})
 ament_package(CONFIG_EXTRAS "${PROJECT_NAME}-extras.cmake")

--- a/ecl_time/CMakeLists.txt
+++ b/ecl_time/CMakeLists.txt
@@ -41,4 +41,5 @@ ament_export_dependencies(
     ecl_exceptions
     ecl_time_lite
 )
+ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_type_traits/CMakeLists.txt
+++ b/ecl_type_traits/CMakeLists.txt
@@ -37,4 +37,5 @@ ament_export_dependencies(
     ecl_config
     ecl_mpl
 )
+ament_export_libraries(${PROJECT_NAME})
 ament_package()


### PR DESCRIPTION
ament_export_libraries() ends up generating a setup.sh file
for each library that exports LD_LIBRARY_PATH.  This is
important when building in isolated mode so that downstream
consumers of the libraries can find the library at runtime.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>