### PR TITLE
[infra] revert workaround for exporting interfaces with libraries

### DIFF
--- a/ecl_devices/CMakeLists.txt
+++ b/ecl_devices/CMakeLists.txt
@@ -47,5 +47,4 @@ ament_export_dependencies(
     ecl_type_traits
     ecl_utilities
 )
-ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_devices/CMakeLists.txt
+++ b/ecl_devices/CMakeLists.txt
@@ -37,7 +37,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
-ament_export_interfaces(${PROJECT_NAME})
+ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config
     ecl_containers

--- a/ecl_exceptions/CMakeLists.txt
+++ b/ecl_exceptions/CMakeLists.txt
@@ -37,5 +37,4 @@ ament_export_dependencies(
     ecl_config
     ecl_errors
 )
-ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_exceptions/CMakeLists.txt
+++ b/ecl_exceptions/CMakeLists.txt
@@ -32,7 +32,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
-ament_export_interfaces(${PROJECT_NAME})
+ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config
     ecl_errors

--- a/ecl_filesystem/CMakeLists.txt
+++ b/ecl_filesystem/CMakeLists.txt
@@ -47,5 +47,4 @@ ament_export_dependencies(
     ecl_config
     ecl_errors
 )
-ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_filesystem/CMakeLists.txt
+++ b/ecl_filesystem/CMakeLists.txt
@@ -42,7 +42,7 @@ add_subdirectory(src)
 # Do we need to export ${ECL_PLATFORM_FILESYSTEM_LIBRARIES} or does that
 # automagically get covered by the exported target with target_link_libraries?
 
-ament_export_interfaces(${PROJECT_NAME})
+ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config
     ecl_errors

--- a/ecl_formatters/CMakeLists.txt
+++ b/ecl_formatters/CMakeLists.txt
@@ -33,7 +33,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
-ament_export_interfaces(${PROJECT_NAME})
+ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config
     ecl_converters

--- a/ecl_formatters/CMakeLists.txt
+++ b/ecl_formatters/CMakeLists.txt
@@ -39,5 +39,4 @@ ament_export_dependencies(
     ecl_converters
     ecl_exceptions
 )
-ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_geometry/CMakeLists.txt
+++ b/ecl_geometry/CMakeLists.txt
@@ -38,7 +38,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
-ament_export_interfaces(${PROJECT_NAME})
+ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config
     ecl_containers

--- a/ecl_geometry/CMakeLists.txt
+++ b/ecl_geometry/CMakeLists.txt
@@ -49,5 +49,4 @@ ament_export_dependencies(
     ecl_mpl
     ecl_type_traits
 )
-ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_ipc/CMakeLists.txt
+++ b/ecl_ipc/CMakeLists.txt
@@ -46,5 +46,4 @@ ament_export_dependencies(
     ecl_time_lite
     ecl_time
 )
-ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_ipc/CMakeLists.txt
+++ b/ecl_ipc/CMakeLists.txt
@@ -37,7 +37,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
-ament_export_interfaces(${PROJECT_NAME})
+ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config
     ecl_errors

--- a/ecl_linear_algebra/CMakeLists.txt
+++ b/ecl_linear_algebra/CMakeLists.txt
@@ -44,5 +44,4 @@ ament_export_dependencies(
     ecl_math
     Sophus
 )
-ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_linear_algebra/CMakeLists.txt
+++ b/ecl_linear_algebra/CMakeLists.txt
@@ -36,7 +36,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
-ament_export_interfaces(${PROJECT_NAME})
+ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_eigen
     ecl_exceptions

--- a/ecl_manipulators/CMakeLists.txt
+++ b/ecl_manipulators/CMakeLists.txt
@@ -50,6 +50,5 @@ ament_export_dependencies(
     ecl_formatters
     ecl_geometry
 )
-ament_export_libraries(${PROJECT_NAME})
 ament_package()
 

--- a/ecl_manipulators/CMakeLists.txt
+++ b/ecl_manipulators/CMakeLists.txt
@@ -44,7 +44,7 @@ install(
 # Exports
 ##############################################################################
 
-ament_export_interfaces(${PROJECT_NAME})
+ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_exceptions
     ecl_formatters

--- a/ecl_mobile_robot/CMakeLists.txt
+++ b/ecl_mobile_robot/CMakeLists.txt
@@ -43,7 +43,6 @@ ament_export_dependencies(
     ecl_linear_algebra
     ecl_math
 )
-ament_export_libraries(${PROJECT_NAME})
 ament_package()
 
 

--- a/ecl_mobile_robot/CMakeLists.txt
+++ b/ecl_mobile_robot/CMakeLists.txt
@@ -35,7 +35,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
-ament_export_interfaces(${PROJECT_NAME})
+ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_errors
     ecl_formatters

--- a/ecl_statistics/CMakeLists.txt
+++ b/ecl_statistics/CMakeLists.txt
@@ -34,7 +34,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
-ament_export_interfaces(${PROJECT_NAME})
+ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config
     ecl_linear_algebra

--- a/ecl_statistics/CMakeLists.txt
+++ b/ecl_statistics/CMakeLists.txt
@@ -41,5 +41,4 @@ ament_export_dependencies(
     ecl_mpl
     ecl_type_traits
 )
-ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_streams/CMakeLists.txt
+++ b/ecl_streams/CMakeLists.txt
@@ -46,5 +46,4 @@ ament_export_dependencies(
     ecl_time
     ecl_type_traits
 )
-ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_streams/CMakeLists.txt
+++ b/ecl_streams/CMakeLists.txt
@@ -37,7 +37,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
-ament_export_interfaces(${PROJECT_NAME})
+ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_concepts
     ecl_converters

--- a/ecl_threads/CMakeLists.txt
+++ b/ecl_threads/CMakeLists.txt
@@ -46,7 +46,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
-ament_export_interfaces(${PROJECT_NAME})
+ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config
     ecl_errors

--- a/ecl_threads/CMakeLists.txt
+++ b/ecl_threads/CMakeLists.txt
@@ -55,5 +55,4 @@ ament_export_dependencies(
     ecl_time
     ecl_utilities
 )
-ament_export_libraries(${PROJECT_NAME})
 ament_package(CONFIG_EXTRAS "${PROJECT_NAME}-extras.cmake")

--- a/ecl_time/CMakeLists.txt
+++ b/ecl_time/CMakeLists.txt
@@ -41,5 +41,4 @@ ament_export_dependencies(
     ecl_exceptions
     ecl_time_lite
 )
-ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_time/CMakeLists.txt
+++ b/ecl_time/CMakeLists.txt
@@ -34,7 +34,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
-ament_export_interfaces(${PROJECT_NAME})
+ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config
     ecl_errors

--- a/ecl_type_traits/CMakeLists.txt
+++ b/ecl_type_traits/CMakeLists.txt
@@ -37,5 +37,4 @@ ament_export_dependencies(
     ecl_config
     ecl_mpl
 )
-ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_type_traits/CMakeLists.txt
+++ b/ecl_type_traits/CMakeLists.txt
@@ -32,7 +32,7 @@ add_subdirectory(src)
 # Exports
 ###############################################################################
 
-ament_export_interfaces(${PROJECT_NAME})
+ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config
     ecl_mpl

--- a/ecl_utilities/CMakeLists.txt
+++ b/ecl_utilities/CMakeLists.txt
@@ -58,7 +58,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
-ament_export_interfaces(${PROJECT_NAME})
+ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_concepts
     ecl_mpl


### PR DESCRIPTION
As brought in, in PR #73

Reported in https://github.com/ament/ament_cmake/issues/132

And fixed in https://github.com/ament/ament_cmake/pull/135/files

This resolves #79