### PR TITLE
export include directories

### DIFF
--- a/ecl_concepts/CMakeLists.txt
+++ b/ecl_concepts/CMakeLists.txt
@@ -59,6 +59,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
+ament_export_include_directories(include)
 ament_export_interfaces(${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config

--- a/ecl_containers/CMakeLists.txt
+++ b/ecl_containers/CMakeLists.txt
@@ -71,6 +71,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
+ament_export_include_directories(include)
 ament_export_interfaces(${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config

--- a/ecl_converters/CMakeLists.txt
+++ b/ecl_converters/CMakeLists.txt
@@ -67,6 +67,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
+ament_export_include_directories(include)
 ament_export_interfaces(${PROJECT_NAME})
 ament_export_dependencies(
     ecl_concepts

--- a/ecl_core_apps/CMakeLists.txt
+++ b/ecl_core_apps/CMakeLists.txt
@@ -35,6 +35,7 @@ find_package(ecl_time_lite REQUIRED)
 ament_package_xml()
 ecl_enable_cxx14_compiler()
 ecl_enable_cxx_warnings()
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-register")
 
 ##############################################################################
 # Sources

--- a/ecl_devices/CMakeLists.txt
+++ b/ecl_devices/CMakeLists.txt
@@ -37,6 +37,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
+ament_export_include_directories(include)
 ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config

--- a/ecl_eigen/CMakeLists.txt
+++ b/ecl_eigen/CMakeLists.txt
@@ -75,6 +75,7 @@ add_subdirectory(license)
 # Export
 ##############################################################################
 
+ament_export_include_directories(include ${EIGEN3_INCLUDE_DIRS})
 ament_export_interfaces(${PROJECT_NAME})
 ament_export_dependencies(Eigen3)
 ament_package()

--- a/ecl_exceptions/CMakeLists.txt
+++ b/ecl_exceptions/CMakeLists.txt
@@ -33,6 +33,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
+ament_export_include_directories(include)
 ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config

--- a/ecl_filesystem/CMakeLists.txt
+++ b/ecl_filesystem/CMakeLists.txt
@@ -43,6 +43,7 @@ add_subdirectory(src)
 # Do we need to export ${ECL_PLATFORM_FILESYSTEM_LIBRARIES} or does that
 # automagically get covered by the exported target with target_link_libraries?
 
+ament_export_include_directories(include)
 ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config

--- a/ecl_formatters/CMakeLists.txt
+++ b/ecl_formatters/CMakeLists.txt
@@ -34,6 +34,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
+ament_export_include_directories(include)
 ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config

--- a/ecl_geometry/CMakeLists.txt
+++ b/ecl_geometry/CMakeLists.txt
@@ -39,6 +39,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
+ament_export_include_directories(include)
 ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config

--- a/ecl_geometry/include/ecl/geometry/legacy_pose3d.hpp
+++ b/ecl_geometry/include/ecl/geometry/legacy_pose3d.hpp
@@ -124,6 +124,8 @@ public:
             rot(RotationMatrix::Identity()),
             trans(Translation::Zero())
         {
+                (void) angle_axis;
+                (void) translation;
                 /* TODO */
         }
         /**

--- a/ecl_ipc/CMakeLists.txt
+++ b/ecl_ipc/CMakeLists.txt
@@ -38,6 +38,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
+ament_export_include_directories(include)
 ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config

--- a/ecl_ipc/src/test/semaphores.cpp
+++ b/ecl_ipc/src/test/semaphores.cpp
@@ -171,7 +171,7 @@ int main(int argc, char **argv) {
 ** Alternative Main
 *****************************************************************************/
 
-int main(int argc, char **argv) {
+int main(int /* argc */, char ** /* argv */) {
     std::cout << std::endl;
     std::cout << "Semaphores are not supported on this platform (or ecl is just lacking)." << std::endl;
     std::cout << std::endl;

--- a/ecl_ipc/src/test/semaphores_timed.cpp
+++ b/ecl_ipc/src/test/semaphores_timed.cpp
@@ -175,7 +175,7 @@ int main(int argc, char **argv) {
 ** Alternative Main
 *****************************************************************************/
 
-int main(int argc, char **argv) {
+int main(int /* argc */, char ** /* argv */) {
     std::cout << std::endl;
     std::cout << "Semaphores are not supported on this platform (or ecl is just lacking)." << std::endl;
     std::cout << std::endl;

--- a/ecl_ipc/src/test/shared_memory.cpp
+++ b/ecl_ipc/src/test/shared_memory.cpp
@@ -149,7 +149,7 @@ int main(int argc, char **argv) {
 ** Alternative Main
 *****************************************************************************/
 
-int main(int argc, char **argv) {
+int main(int /* argc */, char ** /* argv */) {
     std::cout << std::endl;
     std::cout << "Shared memory is not supported on this platform (or ecl is just lacking)." << std::endl;
     std::cout << std::endl;

--- a/ecl_linear_algebra/CMakeLists.txt
+++ b/ecl_linear_algebra/CMakeLists.txt
@@ -37,6 +37,8 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
+get_target_property(IMPORTED_INCLUDE_DIRS Sophus::Sophus INTERFACE_INCLUDE_DIRECTORIES)
+ament_export_include_directories(include ${IMPORTED_INCLUDE_DIRS})
 ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_eigen

--- a/ecl_manipulators/CMakeLists.txt
+++ b/ecl_manipulators/CMakeLists.txt
@@ -45,6 +45,7 @@ install(
 # Exports
 ##############################################################################
 
+ament_export_include_directories(include)
 ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_exceptions

--- a/ecl_math/CMakeLists.txt
+++ b/ecl_math/CMakeLists.txt
@@ -50,6 +50,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
+ament_export_include_directories(include)
 ament_export_interfaces(${PROJECT_NAME})
 ament_export_dependencies(
     ecl_type_traits

--- a/ecl_mobile_robot/CMakeLists.txt
+++ b/ecl_mobile_robot/CMakeLists.txt
@@ -36,6 +36,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
+ament_export_include_directories(include)
 ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_errors

--- a/ecl_mpl/CMakeLists.txt
+++ b/ecl_mpl/CMakeLists.txt
@@ -45,5 +45,6 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
+ament_export_include_directories(include)
 ament_export_interfaces(${PROJECT_NAME})
 ament_package()

--- a/ecl_sigslots/CMakeLists.txt
+++ b/ecl_sigslots/CMakeLists.txt
@@ -59,6 +59,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
+ament_export_include_directories(include)
 ament_export_interfaces(${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config

--- a/ecl_sigslots/include/ecl/sigslots/sigslot.hpp
+++ b/ecl_sigslots/include/ecl/sigslots/sigslot.hpp
@@ -165,7 +165,7 @@ public:
 	 * @brief Disconnect the sigslot from the specified topic.
 	 */
 	void disconnect(const std::string &topic) {
-		std::set<std::string>::const_iterator listen_iter = subscriptions.find(topic);
+		// std::set<std::string>::const_iterator listen_iter = subscriptions.find(topic);
 		publications.erase(topic); // Doesn't matter if it finds it or not.
 		SigSlotsManager<Void>::disconnect(topic,this);
 	}

--- a/ecl_statistics/CMakeLists.txt
+++ b/ecl_statistics/CMakeLists.txt
@@ -35,6 +35,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
+ament_export_include_directories(include)
 ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config

--- a/ecl_streams/CMakeLists.txt
+++ b/ecl_streams/CMakeLists.txt
@@ -38,6 +38,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
+ament_export_include_directories(include)
 ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_concepts

--- a/ecl_threads/CMakeLists.txt
+++ b/ecl_threads/CMakeLists.txt
@@ -47,6 +47,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
+ament_export_include_directories(include)
 ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config

--- a/ecl_threads/include/ecl/threads/thread_pos.hpp
+++ b/ecl_threads/include/ecl/threads/thread_pos.hpp
@@ -243,7 +243,9 @@ public:
 		thread_task(NULL),
 		has_started(false),
 		join_requested(false)
-	{}
+	{
+		(void) schedule_parameters;
+	}
 	/**
 	 * @brief Convenience constructor that starts a new thread with a void global/static function.
 	 *

--- a/ecl_threads/src/lib/mutex_pos.cpp
+++ b/ecl_threads/src/lib/mutex_pos.cpp
@@ -73,7 +73,7 @@ void Mutex::lock()
   ecl_assert_throw(result == 0, threads::throwMutexLockException(LOC,result));
 }
 
-bool Mutex::trylock(Duration &duration)
+bool Mutex::trylock(Duration & /* duration */)
 {
   #if defined(_POSIX_TIMEOUTS) && (_POSIX_TIMEOUTS - 200112L) >= 0L
     timespec timeout;

--- a/ecl_threads/src/lib/priority_pos.cpp
+++ b/ecl_threads/src/lib/priority_pos.cpp
@@ -297,7 +297,7 @@ std::string print_priority_diagnostics() {
 
 namespace threads {
 
-bool set_real_time_priority(int policy,int priority_level) {
+bool set_real_time_priority(int /* policy */,int /* priority_level */) {
 
 	#if _POSIX_PRIORITY_SCHEDULING > 0
 		ostringstream ostream;

--- a/ecl_time/CMakeLists.txt
+++ b/ecl_time/CMakeLists.txt
@@ -35,6 +35,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
+ament_export_include_directories(include)
 ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config

--- a/ecl_type_traits/CMakeLists.txt
+++ b/ecl_type_traits/CMakeLists.txt
@@ -33,6 +33,7 @@ add_subdirectory(src)
 # Exports
 ###############################################################################
 
+ament_export_include_directories(include)
 ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config

--- a/ecl_utilities/CMakeLists.txt
+++ b/ecl_utilities/CMakeLists.txt
@@ -59,6 +59,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
+ament_export_include_directories(include)
 ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_concepts

--- a/ecl_utilities/src/examples/constructors.cpp
+++ b/ecl_utilities/src/examples/constructors.cpp
@@ -21,7 +21,7 @@
 
 class A {
     public:
-        A(int i) : var(i) { std::cout << "Constructor" << std::endl; }
+        A(int i) : var(i) { (void) var; std::cout << "Constructor" << std::endl; }
         A(const A& /* a */) { std::cout << "Copy constructor" << std::endl; }
         ~A() { std::cout << "Destructor" << std::endl; }
         void f() {};


### PR DESCRIPTION
We need this changes in order for colcon to correctly build the turtlebot packages correctly. 
AFAIK, `ament_target_dependencies` does not work with interfaces and there the packages need to explicitly export their include directories.