### PR TITLE
Fix compilation of ecl_threads

### DIFF
--- a/ecl_threads/src/lib/mutex_pos.cpp
+++ b/ecl_threads/src/lib/mutex_pos.cpp
@@ -87,7 +87,7 @@ bool Mutex::trylock(Duration &duration)
     ecl_assert_throw(result == 0, threads::throwMutexTimedLockException(LOC,result));
     ++number_locks;
   #else
-    (void) duration
+    (void) duration;
     return trylock(); // fallback option
   #endif
   return true;


### PR DESCRIPTION
There's a semicolon missing. The change should be pretty clear