### PR TITLE
[exceptions] bugfix dangling pointers on what const char* returns

### DIFF
--- a/ecl_exceptions/CHANGELOG.rst
+++ b/ecl_exceptions/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+1.0.6 (2020-01-11)
+------------------
+* dangling pointer on exceptions fixed, `#96 <https://github.com/stonier/ecl_core/pull/96>`_
+
 0.61.14 (2016-06-16)
 --------------------
 * expose the string message in the exception api

--- a/ecl_exceptions/include/ecl/exceptions/data_exception.hpp
+++ b/ecl_exceptions/include/ecl/exceptions/data_exception.hpp
@@ -70,9 +70,11 @@ class DataException : public Exception
         const Data& data() const { return error_data; } /**< @brief The bundled data object. **/
 
     private:
+        void create_combined_message();
         ErrorFlag error_type;
         Data error_data;
         std::string message;
+        std::string combined_message;
 };
 
 /*****************************************************************************
@@ -89,7 +91,9 @@ DataException<Data>::DataException(const char* loc, ErrorFlag error, Data &d ) :
     Exception(loc),
     error_type(error),
     error_data(d)
-{}
+{
+    create_combined_message();
+}
 /**
  * Constructor for data exceptions with a custom message.
  * @param loc : use with the LOC macro, identifies the line and file of the code.
@@ -103,7 +107,9 @@ DataException<Data>::DataException(const char* loc, ErrorFlag error, const std::
     error_type(error),
     error_data(d),
     message(msg)
-{}
+{
+    create_combined_message();
+}
 /**
  * Constructor for data exceptions that enables rethrowing of an existing exception up
  * the heirarchy with a new code location stamp.
@@ -118,16 +124,14 @@ DataException<Data>::DataException(const char* loc, const DataException<Data> &e
     message(e.message)
 {
     location = std::string(loc) + "\n         : " + e.location;
+    create_combined_message();
 }
+
 /**
- * Default exception handling output function.
- *
- * @return char const* : the output message.
+ * Create the combined error message and store it.
  */
 template <typename Data>
-const char* DataException<Data>::what() const throw() {
-
-    std::string what_msg;
+void DataException<Data>::create_combined_message() {
 
     std::ostringstream stream;
     stream << "\n" << "Location : " << this->location << "\n";
@@ -136,8 +140,17 @@ const char* DataException<Data>::what() const throw() {
         stream << "Detail   : " << message << "\n";
     }
     stream << "Data     : " << error_data << "\n";
-    what_msg = stream.str();
-    return what_msg.c_str();
+    this->combined_message = stream.str();
+}
+
+/**
+ * Default exception handling output function.
+ *
+ * @return char const* : the output message.
+ */
+template <typename Data>
+const char* DataException<Data>::what() const throw() {
+    return combined_message.c_str();
 }
 
 } // namespace ecl

--- a/ecl_exceptions/include/ecl/exceptions/standard_exception.hpp
+++ b/ecl_exceptions/include/ecl/exceptions/standard_exception.hpp
@@ -80,7 +80,7 @@ class ecl_exceptions_PUBLIC StandardException : public Exception
         /**
          * Default exception handling output function.
          *
-         * @return char const* : the output message.
+         * @return const char* : the combined (LOC, error flag, detailed message) error string.
          */
         const char* what() const throw();
 
@@ -94,8 +94,12 @@ class ecl_exceptions_PUBLIC StandardException : public Exception
         const ErrorFlag& flag() const { return error_flag; }  /**< @brief Flag enumerating the type of exception thrown. **/
 
     private:
+
+        void create_combined_message();
+
         const ErrorFlag error_flag;
         std::string detailed_message;
+        std::string combined_message;
 };
 
 } // namespace ecl

--- a/ecl_exceptions/src/lib/standard_exception.cpp
+++ b/ecl_exceptions/src/lib/standard_exception.cpp
@@ -10,6 +10,7 @@
 *****************************************************************************/
 
 #include <ecl/config/ecl.hpp>
+#include <iostream>
 #ifndef ECL_DISABLE_EXCEPTIONS
 
 /*****************************************************************************
@@ -31,13 +32,17 @@ namespace ecl {
 StandardException::StandardException(const char* loc, ErrorFlag error ) :
     Exception(loc),
     error_flag(error)
-{}
+{
+    create_combined_message();
+}
 
 StandardException::StandardException(const char* loc, ErrorFlag error, const std::string &msg ) :
     Exception(loc),
     error_flag(error),
     detailed_message(msg)
-{}
+{
+    create_combined_message();
+}
 
 StandardException::StandardException(const char* loc, const StandardException &e ) :
     Exception(),
@@ -45,17 +50,18 @@ StandardException::StandardException(const char* loc, const StandardException &e
     detailed_message(e.detailed_message)
 {
     location = std::string(loc) + "\n         : " + e.location;
+    create_combined_message();
 }
 
+void StandardException::create_combined_message() {
+    this->combined_message = "\nLocation : " + this->location + "\n" + "Flag     : " + Error(error_flag).what() + "\n";
+    if ( this->detailed_message.size() > 0 ) {
+        combined_message  = combined_message + "Detail   : " + detailed_message + "\n";
+    }
+}
 const char* StandardException::what() const throw() {
 
-    std::string what_msg;
-
-    what_msg = what_msg + "\nLocation : " + this->location + "\n" + "Flag     : " + Error(error_flag).what() + "\n";
-    if ( detailed_message.size() > 0 ) {
-        what_msg  = what_msg + "Detail   : " + detailed_message + "\n";
-    }
-    return what_msg.c_str();
+	return combined_message.c_str();
 }
 
 } // namespace ecl


### PR DESCRIPTION
Creates the storage on construction (RAII style objects) and passes that out instead.

* Resolves #15.
* Resolves #92.