### PR TITLE
Fix two warnings that show up when building.

### DIFF
--- a/ecl_concepts/include/ecl/concepts/nullary_function.hpp
+++ b/ecl_concepts/include/ecl/concepts/nullary_function.hpp
@@ -45,7 +45,6 @@ class NullaryFunctionConcept {
          */
 		ecl_compile_time_concept_test(NullaryFunctionConcept)
         {
-        	typedef typename Implementation::result_type return_type;
         	function();
         	// Unfortunately we can't test for the result type to match a certain value here
         	// as this would then have 2 template arguments with a separating comma. That throws

--- a/ecl_streams/include/ecl/streams/socket_streams.hpp
+++ b/ecl_streams/include/ecl/streams/socket_streams.hpp
@@ -109,7 +109,7 @@ public:
 	 *
 	 * @exception StandardException : throws if the connection failed to open.
 	 */
-	SocketServerStream(const unsigned int &port_number) throw(StandardException) {
+	SocketServerStream(const unsigned int &port_number) {
 		try {
 			this->device().open(port_number);
 		} catch(StandardException &e) {


### PR DESCRIPTION
One is an unused typedef, and the other is the use of the
deprecated "throw" attribute on a method.  With this in
place, everything builds without warnings or errors.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Fixes #93 