### PR TITLE
Make sure to export devices and mobile_robot.

### DIFF
--- a/ecl_devices/CMakeLists.txt
+++ b/ecl_devices/CMakeLists.txt
@@ -51,4 +51,7 @@ ament_export_dependencies(
     ecl_type_traits
     ecl_utilities
 )
+ament_export_include_directories(include)
+# TODO: deprecate this line post 'ardent' (been fixed upstream)
+ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_mobile_robot/CMakeLists.txt
+++ b/ecl_mobile_robot/CMakeLists.txt
@@ -48,7 +48,7 @@ ament_export_dependencies(
     ecl_linear_algebra
     ecl_math
 )
+ament_export_include_directories(include)
+# TODO: deprecate this line post 'ardent' (been fixed upstream)
+ament_export_libraries(${PROJECT_NAME})
 ament_package()
-
-
-


### PR DESCRIPTION
Otherwise, downstream consumers won't properly get the
include directories from transitive dependencies.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Note that this should fix the problem pointed out in https://github.com/kobuki-base/kobuki_ros/pull/4#pullrequestreview-348429445, though we'll need a release and a follow-up PR on that repository once we merge this.