### PR TITLE
Fix unused variable errors

### DIFF
--- a/ecl_concepts/include/ecl/concepts/containers.hpp
+++ b/ecl_concepts/include/ecl/concepts/containers.hpp
@@ -290,6 +290,7 @@ public:
 		n = container.size();
 		// If not a char, this results in a private call -> compile time error!
 		concepts::SignedByteTestCheck<element_type> char_test;
+		(void) n;
 	}
 
 private:

--- a/ecl_concepts/include/ecl/concepts/devices.hpp
+++ b/ecl_concepts/include/ecl/concepts/devices.hpp
@@ -138,6 +138,8 @@ public:
 		no_written = input_output_char_device.write('\n');
 		no_written = input_output_char_device.write(write_buffer,5);
 		input_output_char_device.flush();
+		(void) no_written;
+		(void) no_read;
 	}
 private:
 	// Putting instantiations here actually saves instantiation (which can cause a
@@ -184,6 +186,8 @@ public:
 		no_read = input_byte_device.read(buffer,10);
 		no_read = input_byte_device.read(usc);
 		no_read = input_byte_device.read(usbuffer,10);
+		(void) result;
+		(void) no_read;
 	}
 
 private:
@@ -233,6 +237,8 @@ public:
 		no_written = output_byte_device.write(write_buffer,5);
 		no_written = output_byte_device.write(us_write_buffer,5);
 		output_byte_device.flush();
+		(void) no_written;
+		(void) result;
 	}
 
 private:
@@ -299,6 +305,9 @@ public:
 		no_written = input_output_byte_device.write(write_buffer,5);
 		no_written = input_output_byte_device.write(us_write_buffer,5);
 		input_output_byte_device.flush();
+		(void) no_read;
+		(void) no_written;
+		(void) result;
 	}
 private:
 	// Putting instantiations here actually saves instantiation (which can cause a

--- a/ecl_core_apps/src/utils/hex.cpp
+++ b/ecl_core_apps/src/utils/hex.cpp
@@ -71,7 +71,7 @@ public:
 		serial(serial_device),
 		hex_format(-1,NoAlign,Hex),
 		thread(&Writer::run,*this)
-		{}
+		{ (void) current_time; }
 	void wait() { thread.join(); }
 
 private:
@@ -123,7 +123,7 @@ public:
 		format(6,RightAlign,Dec),
 		hex_format(-1,NoAlign,Hex),
 		thread(&Reader::run,*this)
-		{}
+		{ (void) current_time; }
 
 	void wait() { thread.join(); }
 

--- a/ecl_core_apps/src/utils/serial.cpp
+++ b/ecl_core_apps/src/utils/serial.cpp
@@ -65,7 +65,7 @@ public:
 		display_timestamps(timestamps),
 		serial(serial_device),
 		thread(&Writer::run,*this)
-		{}
+		{ (void) current_time; }
 	void wait() { thread.join(); }
 
 private:
@@ -113,7 +113,7 @@ public:
 		format(6,RightAlign,Dec),
 		hex_format(-1,NoAlign,Hex),
 		thread(&Reader::run,*this)
-		{}
+		{ (void) current_time; }
 
 	void wait() { thread.join(); }
 

--- a/ecl_core_apps/src/utils/socket_server.cpp
+++ b/ecl_core_apps/src/utils/socket_server.cpp
@@ -64,7 +64,7 @@ public:
 		hex(hex_format_reqd),
 		port(port_number),
 		new_line(true)
-	{}
+	{ (void) port; }
 
 	void loop() {
 

--- a/ecl_utilities/include/ecl/utilities/void.hpp
+++ b/ecl_utilities/include/ecl/utilities/void.hpp
@@ -73,7 +73,7 @@ public:
  * @return OutputStream : return the output stream as is.
  **/
 template <typename OutputStream>
-OutputStream& operator << (OutputStream& ostream, const Void void_object) { return ostream; }
+OutputStream& operator << (OutputStream& ostream, const Void void_object) { (void) void_object; return ostream; }
 
 } // namespace ecl
 


### PR DESCRIPTION
Fix some more unused variable errors occuring on Ubuntu 22.04 using clang on ROS2 humble.