### PR TITLE
Added overload for derivative and dderivative

### DIFF
--- a/ecl_geometry/include/ecl/geometry/cubic_spline.hpp
+++ b/ecl_geometry/include/ecl/geometry/cubic_spline.hpp
@@ -186,6 +186,7 @@ class ECL_PUBLIC CubicSpline : public BluePrintFactory< CubicSpline > {
          * @exception : StandardException : throws if input x value is outside the spline range [debug mode only].
          */
         double derivative(double x) const;
+        std::map<int, double> derivative(const int &last_index, const double &x) const;
         /**
          * @brief Spline second derivative.
          *
@@ -195,7 +196,7 @@ class ECL_PUBLIC CubicSpline : public BluePrintFactory< CubicSpline > {
          * @exception : StandardException : throws if input x value is outside the spline range [debug mode only].
          */
         double dderivative(double x) const;
-
+        std::map<int, double> dderivative(const int &last_index, const double &x) const;
         /**
          * @brief The discretised domain for this spline.
          *

--- a/ecl_geometry/include/ecl/geometry/cubic_spline.hpp
+++ b/ecl_geometry/include/ecl/geometry/cubic_spline.hpp
@@ -177,6 +177,7 @@ class ECL_PUBLIC CubicSpline : public BluePrintFactory< CubicSpline > {
          * @exception : StandardException : throws if input x value is outside the spline range [debug mode only].
          */
         double operator()(const double &x) const;
+        std::map<int, double> operator()(int last_index, const double &x);
         /**
          * @brief Spline derivative.
          *

--- a/ecl_geometry/include/ecl/geometry/smooth_linear_spline.hpp
+++ b/ecl_geometry/include/ecl/geometry/smooth_linear_spline.hpp
@@ -88,6 +88,8 @@ public:
 	 * @exception : StandardException : throws if x is outside the spline range [debug mode only].
 	 */
 	double operator()(const double &x) const;
+	std::map<int, double> operator()(const int &last_index,const double &x) const;
+
 	/**
 	 * @brief Spline derivative.
 	 *
@@ -153,7 +155,7 @@ public:
 	 * @brief Streaming output insertion operator for smoothed linear splines.
 	 *
 	 * Streaming output insertion operator for smoothed linear splines. This
-	 * simply lists the spline segments and corners (linear functions and
+	 * simply lists the spline segments and corners (linear functions andTensionSpline
 	 * quintic polynomials) in algebraic form.
 	 *
 	 * @tparam OutputStream : the type of stream being used.

--- a/ecl_geometry/include/ecl/geometry/smooth_linear_spline.hpp
+++ b/ecl_geometry/include/ecl/geometry/smooth_linear_spline.hpp
@@ -99,6 +99,8 @@ public:
 	 * @exception : StandardException : throws if x is outside the spline range [debug mode only].
 	 */
 	double derivative(const double &x) const;
+	std::map<int, double> derivative(const int &last_index, const double &x) const;
+
 	/**
 	 * @brief Spline second derivative.
 	 *
@@ -108,6 +110,7 @@ public:
 	 * @exception : StandardException : throws if x is outside the spline range [debug mode only].
 	 */
 	double dderivative(const double &x) const;
+	std::map<int, double> dderivative(const int &last_index, const double &x) const;
 
 	/**
 	 * @brief The discretised domain for this spline.

--- a/ecl_geometry/include/ecl/geometry/tension_spline.hpp
+++ b/ecl_geometry/include/ecl/geometry/tension_spline.hpp
@@ -25,6 +25,7 @@
 #include <ecl/exceptions/standard_exception.hpp>
 #include <ecl/utilities/blueprints.hpp>
 #include "macros.hpp"
+#include <map>
 
 /*****************************************************************************
 ** Namespaces
@@ -167,6 +168,8 @@ class ecl_geometry_PUBLIC TensionSpline : public BluePrintFactory< TensionSpline
          * @exception : StandardException : throws if x is outside the spline range [debug mode only].
          */
         double derivative(const double &x) const;
+
+  std::map<int, double> derivative(const int &last_index, const double &x) const;
         /**
          * @brief Spline second derivative.
          *
@@ -176,6 +179,8 @@ class ecl_geometry_PUBLIC TensionSpline : public BluePrintFactory< TensionSpline
          * @exception : StandardException : throws if x is outside the spline range [debug mode only].
          */
         double dderivative(const double &x) const;
+
+        std::map<int, double> dderivative(const int &last_index, const double &x) const;
 
         /**
          * @brief The discretised domain for this spline.

--- a/ecl_geometry/include/ecl/geometry/tension_spline.hpp
+++ b/ecl_geometry/include/ecl/geometry/tension_spline.hpp
@@ -157,6 +157,8 @@ class ecl_geometry_PUBLIC TensionSpline : public BluePrintFactory< TensionSpline
          * @exception : StandardException : throws if x is outside the spline range [debug mode only].
          */
         double operator()(const double &x) const;
+
+        std::map<int, double> operator()(const int &last_index, const double &x) const;
         /**
          * @brief Spline derivative.
          *
@@ -169,7 +171,7 @@ class ecl_geometry_PUBLIC TensionSpline : public BluePrintFactory< TensionSpline
          */
         double derivative(const double &x) const;
 
-  std::map<int, double> derivative(const int &last_index, const double &x) const;
+        std::map<int, double> derivative(const int &last_index, const double &x) const;
         /**
          * @brief Spline second derivative.
          *

--- a/ecl_geometry/src/lib/cubic_spline.cpp
+++ b/ecl_geometry/src/lib/cubic_spline.cpp
@@ -44,6 +44,16 @@ double CubicSpline::derivative(double x) const {
     return cubic_polynomials[index].derivative()(x);
 }
 
+std::map<int, double> CubicSpline::derivative(const int &last_index, const double &x) const {
+    ecl_assert_throw( ( ( x >= discretised_domain.front() ) && ( x <= discretised_domain.back() ) ), StandardException(LOC,OutOfRangeError) );
+    int index = last_index;
+    while ( x > discretised_domain[index+1] ) {
+      ++index;
+    }
+    std::map<int, double> m = {{index, cubic_polynomials[index].derivative()(x)}};
+    return m;
+}
+
 double CubicSpline::dderivative(double x) const {
     ecl_assert_throw( ( ( x >= discretised_domain.front() ) && ( x <= discretised_domain.back() ) ), StandardException(LOC,OutOfRangeError) );
     int index = 0;
@@ -52,5 +62,16 @@ double CubicSpline::dderivative(double x) const {
     }
     return cubic_polynomials[index].derivative().derivative()(x);
 }
+
+std::map<int, double> CubicSpline::dderivative(const int &last_index, const double &x) const {
+    ecl_assert_throw( ( ( x >= discretised_domain.front() ) && ( x <= discretised_domain.back() ) ), StandardException(LOC,OutOfRangeError) );
+    int index = last_index;
+    while ( x > discretised_domain[index+1] ) {
+      ++index;
+    }
+    std::map<int, double> m = {{index, cubic_polynomials[index].derivative().derivative()(x)}};
+    return m;
+}
+
 
 } // namespace ecl

--- a/ecl_geometry/src/lib/cubic_spline.cpp
+++ b/ecl_geometry/src/lib/cubic_spline.cpp
@@ -35,6 +35,16 @@ double CubicSpline::operator()(const double &x) const {
     return cubic_polynomials[index](x);
 }
 
+std::map<int, double> CubicSpline::operator()(int last_index, const double &x) {
+  ecl_assert_throw( ( ( x >= discretised_domain.front() ) && ( x <= discretised_domain.back() ) ), StandardException(LOC,OutOfRangeError) );
+  int index = last_index;
+  while ( x > discretised_domain[index+1] ) {
+    ++index;
+  }
+  std::map<int, double> m = {{index, cubic_polynomials[index](x)}};
+  return m;
+}
+
 double CubicSpline::derivative(double x) const {
     ecl_assert_throw( ( ( x >= discretised_domain.front() ) && ( x <= discretised_domain.back() ) ), StandardException(LOC,OutOfRangeError) );
     int index = 0;

--- a/ecl_geometry/src/lib/smooth_linear_spline.cpp
+++ b/ecl_geometry/src/lib/smooth_linear_spline.cpp
@@ -122,6 +122,21 @@ double SmoothLinearSpline::operator()(const double &x) const {
     }
 }
 
+std::map<int, double> SmoothLinearSpline::operator()(const int &last_index, const double &x) const {
+    ecl_assert_throw( ( ( x >= discretised_domain.front() ) && ( x <= discretised_domain.back() ) ), StandardException(LOC,OutOfRangeError) );
+    int index = last_index;
+    while ( x > discretised_domain[index+1] ) {
+        ++index;
+    }
+    if ( index % 2 == 0 ) { // linear
+		std::map<int,double> m = {{index,segments[index/2](x)}};
+    	return m;
+    } else { // quintic
+		std::map<int,double> m = {{index, corners[(index-1)/2](x)}};
+    	return m;
+    }
+}
+
 double SmoothLinearSpline::derivative(const double &x) const {
     ecl_assert_throw( ( ( x >= discretised_domain.front() ) && ( x <= discretised_domain.back() ) ), StandardException(LOC,OutOfRangeError) );
     int index = 0;

--- a/ecl_geometry/src/lib/smooth_linear_spline.cpp
+++ b/ecl_geometry/src/lib/smooth_linear_spline.cpp
@@ -135,6 +135,23 @@ double SmoothLinearSpline::derivative(const double &x) const {
     }
 }
 
+std::map<int, double> SmoothLinearSpline::derivative(const int &last_index, const double &x) const {
+  ecl_assert_throw( ( ( x >= discretised_domain.front() ) && ( x <= discretised_domain.back() ) ), StandardException(LOC,OutOfRangeError) );
+  int index = last_index;
+  while ( x > discretised_domain[index+1] ) {
+    ++index;
+  }
+  std::map<int, double> m;
+  if ( index % 2 == 0 )
+  { // linear
+    std::map<int,double> m = {{index,segments[index/2].derivative(x)}};
+	return m;
+  } else { // quintic
+	std::map<int,double> m = {{index,corners[(index-1)/2].derivative(x)}};
+	return m;
+  }
+}
+
 double SmoothLinearSpline::dderivative(const double &x) const {
     ecl_assert_throw( ( ( x >= discretised_domain.front() ) && ( x <= discretised_domain.back() ) ), StandardException(LOC,OutOfRangeError) );
     int index = 0;
@@ -146,6 +163,23 @@ double SmoothLinearSpline::dderivative(const double &x) const {
     } else { // quintic
     	return corners[(index-1)/2].dderivative(x);
     }
+}
+
+std::map<int, double> SmoothLinearSpline::dderivative(const int &last_index, const double &x) const {
+  ecl_assert_throw( ( ( x >= discretised_domain.front() ) && ( x <= discretised_domain.back() ) ), StandardException(LOC,OutOfRangeError) );
+  int index = last_index;
+  while ( x > discretised_domain[index+1] ) {
+    ++index;
+  }
+  std::map<int, double> m;
+  if ( index % 2 == 0 )
+  { // linear
+    std::map<int,double> m = {{index,segments[index/2].dderivative(x)}};
+	return m;
+  } else { // quintic
+	std::map<int,double> m = {{index,corners[(index-1)/2].dderivative(x)}};
+	return m;
+  }
 }
 
 } // namespace ecl

--- a/ecl_geometry/src/lib/tension_spline.cpp
+++ b/ecl_geometry/src/lib/tension_spline.cpp
@@ -35,6 +35,16 @@ double TensionSpline::operator()(const double &x) const {
     return functions[index](tension,x);
 }
 
+std::map<int, double> TensionSpline::operator()(const int &last_index, const double &x) const {
+    ecl_assert_throw( ( ( x >= discretised_domain.front() ) && ( x <= discretised_domain.back() ) ), StandardException(LOC,OutOfRangeError) );
+    int index = last_index;
+    while ( x > discretised_domain[index+1] ) {
+        ++index;
+    }
+    std::map<int, double> m = {{index, functions[index](tension,x)}};
+    return m;
+}
+
 double TensionSpline::derivative(const double &x) const {
     ecl_assert_throw( ( ( x >= discretised_domain.front() ) && ( x <= discretised_domain.back() ) ), StandardException(LOC,OutOfRangeError) );
     int index = 0;

--- a/ecl_geometry/src/lib/tension_spline.cpp
+++ b/ecl_geometry/src/lib/tension_spline.cpp
@@ -44,6 +44,16 @@ double TensionSpline::derivative(const double &x) const {
     return functions[index].derivative(tension,x);
 }
 
+  std::map<int, double> TensionSpline::derivative(const int &last_index, const double &x) const {
+    ecl_assert_throw( ( ( x >= discretised_domain.front() ) && ( x <= discretised_domain.back() ) ), StandardException(LOC,OutOfRangeError) );
+    int index = last_index;
+    while ( x > discretised_domain[index+1] ) {
+      ++index;
+    }
+    std::map<int, double> m = {{index, functions[index].derivative(tension,x)}};
+    return m;
+  }
+
 double TensionSpline::dderivative(const double &x) const {
     ecl_assert_throw( ( ( x >= discretised_domain.front() ) && ( x <= discretised_domain.back() ) ), StandardException(LOC,OutOfRangeError) );
     int index = 0;
@@ -51,6 +61,16 @@ double TensionSpline::dderivative(const double &x) const {
         ++index;
     }
     return functions[index].dderivative(tension,x);
+}
+
+std::map<int, double> TensionSpline::dderivative(const int &last_index, const double &x) const {
+  ecl_assert_throw( ( ( x >= discretised_domain.front() ) && ( x <= discretised_domain.back() ) ), StandardException(LOC,OutOfRangeError) );
+  int index = last_index;
+  while ( x > discretised_domain[index+1] ) {
+    ++index;
+  }
+  std::map<int, double> m = {{index, functions[index].dderivative(tension, x)}};
+  return m;
 }
 
 } // namespace ecl


### PR DESCRIPTION
* In TensionSpline::derivative and TensionSpline::dderivative I created an overloaded function that takes in a starting index and outputs the last index.

If there are many points in your spline, this improves performance greatly, assuming you know where to start your index.

Without this we were seeing large time increases as the spline length increased.