### PR TITLE
Replacing BSD with BSD-3-Clause in package.xml

### DIFF
--- a/ecl_command_line/package.xml
+++ b/ecl_command_line/package.xml
@@ -7,7 +7,7 @@
      command line parser in templatised c++.
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_command_line</url>
   <url type="repository">https://github.com/stonier/ecl_core</url>
   <url type="bugtracker">https://github.com/stonier/ecl_core/issues</url>

--- a/ecl_concepts/package.xml
+++ b/ecl_concepts/package.xml
@@ -8,7 +8,7 @@
      template arguments.
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_concepts</url>
   <url type="repository">https://github.com/stonier/ecl_core</url>
   <url type="bugtracker">https://github.com/stonier/ecl_core/issues</url>

--- a/ecl_containers/package.xml
+++ b/ecl_containers/package.xml
@@ -11,7 +11,7 @@
     as buffer overruns.
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_containers</url>
   <url type="repository">https://github.com/stonier/ecl_core</url>
   <url type="bugtracker">https://github.com/stonier/ecl_core/issues</url>

--- a/ecl_converters/package.xml
+++ b/ecl_converters/package.xml
@@ -10,7 +10,7 @@
      They will come as the need arises.
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_converters</url>
   <url type="repository">https://github.com/stonier/ecl_core</url>
   <url type="bugtracker">https://github.com/stonier/ecl_core/issues</url>

--- a/ecl_core/package.xml
+++ b/ecl_core/package.xml
@@ -8,7 +8,7 @@
     programming.
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://www.ros.org/wiki/ecl_core</url>
   <url type="repository">https://github.com/stonier/ecl_core</url>
   <url type="bugtracker">https://github.com/stonier/ecl_core/issues</url>

--- a/ecl_core_apps/package.xml
+++ b/ecl_core_apps/package.xml
@@ -8,7 +8,7 @@
      use primarily with embedded systems.
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_core_apps</url>
   <url type="repository">https://github.com/stonier/ecl_core</url>
   <url type="bugtracker">https://github.com/stonier/ecl_core/issues</url>

--- a/ecl_devices/package.xml
+++ b/ecl_devices/package.xml
@@ -6,7 +6,7 @@
      Provides an extensible and standardised framework for input-output devices.
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_devices</url>
   <url type="repository">https://github.com/stonier/ecl_core</url>
   <url type="bugtracker">https://github.com/stonier/ecl_core/issues</url>

--- a/ecl_eigen/package.xml
+++ b/ecl_eigen/package.xml
@@ -6,7 +6,7 @@
      This provides an Eigen implementation for ecl's linear algebra.
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_eigen</url>
   <url type="repository">https://github.com/stonier/ecl_core</url>
   <url type="bugtracker">https://github.com/stonier/ecl_core/issues</url>

--- a/ecl_exceptions/package.xml
+++ b/ecl_exceptions/package.xml
@@ -8,7 +8,7 @@
      syntatactically ideal, it is convenient and eminently practical.
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_exceptions</url>
   <url type="repository">https://github.com/stonier/ecl_core</url>
   <url type="bugtracker">https://github.com/stonier/ecl_core/issues</url>

--- a/ecl_filesystem/package.xml
+++ b/ecl_filesystem/package.xml
@@ -6,7 +6,7 @@
      Cross platform filesystem utilities (until c++11 makes its way in).
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_filesystem</url>
   <url type="repository">https://github.com/stonier/ecl_core</url>
   <url type="bugtracker">https://github.com/stonier/ecl_core/issues</url>

--- a/ecl_formatters/package.xml
+++ b/ecl_formatters/package.xml
@@ -8,7 +8,7 @@
    ecl and stl streams).
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_formatters</url>
   <url type="repository">https://github.com/stonier/ecl_core</url>
   <url type="bugtracker">https://github.com/stonier/ecl_core/issues</url>

--- a/ecl_geometry/package.xml
+++ b/ecl_geometry/package.xml
@@ -7,7 +7,7 @@
      Primarily featuring polynomials and interpolations.
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_geometry</url>
   <url type="repository">https://github.com/stonier/ecl_core</url>
   <url type="bugtracker">https://github.com/stonier/ecl_core/issues</url>

--- a/ecl_ipc/package.xml
+++ b/ecl_ipc/package.xml
@@ -10,7 +10,7 @@
   to be done consistently across platforms.
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_ipc</url>
   <url type="repository">https://github.com/stonier/ecl_core</url>
   <url type="bugtracker">https://github.com/stonier/ecl_core/issues</url>

--- a/ecl_linear_algebra/package.xml
+++ b/ecl_linear_algebra/package.xml
@@ -6,7 +6,7 @@
      Ecl frontend to a linear matrix package (currently eigen).
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_linear_algebra</url>
   <url type="repository">https://github.com/stonier/ecl_core</url>
   <url type="bugtracker">https://github.com/stonier/ecl_core/issues</url>

--- a/ecl_manipulators/package.xml
+++ b/ecl_manipulators/package.xml
@@ -7,7 +7,7 @@
     feedforward filters (interpolations).
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_manipulators</url>
   <url type="repository">https://github.com/stonier/ecl_manipulation</url>
   <url type="bugtracker">https://github.com/stonier/ecl_manipulation/issues</url>

--- a/ecl_math/package.xml
+++ b/ecl_math/package.xml
@@ -7,7 +7,7 @@
     or redefining in a c++ formulation where desirable.
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_math</url>
   <url type="repository">https://github.com/stonier/ecl_core</url>
   <url type="bugtracker">https://github.com/stonier/ecl_core/issues</url>

--- a/ecl_mobile_robot/package.xml
+++ b/ecl_mobile_robot/package.xml
@@ -7,7 +7,7 @@
     for the various types of mobile robot platforms.
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_mobile_robot</url>
   <url type="repository">https://github.com/stonier/ecl_navigation</url>
   <url type="bugtracker">https://github.com/stonier/ecl_navigation/issues</url>

--- a/ecl_mpl/package.xml
+++ b/ecl_mpl/package.xml
@@ -7,7 +7,7 @@
     compile time. This has only very elementary structures at this stage.
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_mpl</url>
   <url type="repository">https://github.com/stonier/ecl_core</url>
   <url type="bugtracker">https://github.com/stonier/ecl_core/issues</url>

--- a/ecl_sigslots/package.xml
+++ b/ecl_sigslots/package.xml
@@ -10,7 +10,7 @@
      and are multithread-safe.
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://ros.org/wiki/ecl_sigslots</url>
   <url type="repository">https://github.com/stonier/ecl_core</url>
   <url type="bugtracker">https://github.com/stonier/ecl_core/issues</url>

--- a/ecl_statistics/package.xml
+++ b/ecl_statistics/package.xml
@@ -6,7 +6,7 @@
      Common statistical structures and algorithms for control systems.
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_statistics</url>
   <url type="repository">https://github.com/stonier/ecl_core</url>
   <url type="bugtracker">https://github.com/stonier/ecl_core/issues</url>

--- a/ecl_streams/package.xml
+++ b/ecl_streams/package.xml
@@ -7,7 +7,7 @@
      ecl type devices.
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_streams</url>
   <url type="repository">https://github.com/stonier/ecl_core</url>
   <url type="bugtracker">https://github.com/stonier/ecl_core/issues</url>

--- a/ecl_threads/package.xml
+++ b/ecl_threads/package.xml
@@ -9,7 +9,7 @@
      is also implemented.
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_threads</url>
   <url type="repository">https://github.com/stonier/ecl_core</url>
   <url type="bugtracker">https://github.com/stonier/ecl_core/issues</url>

--- a/ecl_time/package.xml
+++ b/ecl_time/package.xml
@@ -11,7 +11,7 @@
 	- win : none.
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_time</url>
   <url type="repository">https://github.com/stonier/ecl_core</url>
   <url type="bugtracker">https://github.com/stonier/ecl_core/issues</url>

--- a/ecl_type_traits/package.xml
+++ b/ecl_type_traits/package.xml
@@ -6,7 +6,7 @@
      Extends c++ type traits and implements a few more to boot.
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_type_traits</url>
   <url type="repository">https://github.com/stonier/ecl_core</url>
   <url type="bugtracker">https://github.com/stonier/ecl_core/issues</url>

--- a/ecl_utilities/package.xml
+++ b/ecl_utilities/package.xml
@@ -6,7 +6,7 @@
      Includes various supporting tools and utilities for c++ programming.
   </description>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_utilities</url>
   <url type="repository">https://github.com/stonier/ecl_core</url>
   <url type="bugtracker">https://github.com/stonier/ecl_core/issues</url>


### PR DESCRIPTION
Updating the package.xml license tags to hold valid SPDX qualifiers. The rationale behind this is, that with
[meta-ros](https://github.com/ros/meta-ros) and
[superflore](https://github.com/ros-infrastructure/superflore) recipes get generated for the OpenEmbedded Linux build system. It will fetch the license tag and copy it over into the recipe. If no valid SPDX identifiers get found, it will issue an error, and a manual step to fix this is needed.

See the SPDX identifiers
[BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html)