### PR TITLE
[ecl_utilities] Fix maybe-uninitilized error in tests

### DIFF
--- a/ecl_utilities/src/test/function_objects.cpp
+++ b/ecl_utilities/src/test/function_objects.cpp
@@ -144,7 +144,8 @@ TEST(FunctionObjects,boundMemberFunctions) {
     bmufo1();
     EXPECT_EQ(0,a.result);
 
-    BoundUnaryMemberFunction<MemberFunctions,const int&,void> bmbfo1(&MemberFunctions::f, a, 3);
+    int j = 3;
+    BoundUnaryMemberFunction<MemberFunctions,const int&,void> bmbfo1(&MemberFunctions::f, a, j);
     bmbfo1();
     EXPECT_EQ(1,a.result);
 }


### PR DESCRIPTION
When building on ROS 2 Jazzy / Ubuntu Noble, ecl_utilities fails when build testing is enabled.

```
In file included from src/ecl_core/ecl_utilities/src/test/function_objects.cpp:13:
In member function ‘R ecl::BoundUnaryMemberFunction<C, A, R>::operator()() [with C = ecl::utilities::tests::MemberFunctions; A = const int&; R = void]’,
    inlined from ‘virtual void FunctionObjects_boundMemberFunctions_Test::TestBody()’ at src/ecl_core/ecl_utilities/src/test/function_objects.cpp:148:11:
src/ecl_core/ecl_utilities/src/test/../../include/ecl/utilities/function_objects.hpp:769:55: error: ‘<anonymous>’ may be used uninitialized [-Werror=maybe-uninitialized]
  769 |                 return (member_class.*member_function)(argument);
      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
src/ecl_core/ecl_utilities/src/test/function_objects.cpp: In member function ‘virtual void FunctionObjects_boundMemberFunctions_Test::TestBody()’:
src/ecl_core/ecl_utilities/src/test/function_objects.cpp:44:14: note: by argument 2 of type ‘const int&’ to ‘void ecl::utilities::tests::MemberFunctions::f(const int&)’ declared here
   44 |         void f(const int &i) {
      |              ^
ecl_core/ecl_utilities/src/test/function_objects.cpp:147:95: note: ‘<anonymous>’ declared here
  147 |     BoundUnaryMemberFunction<MemberFunctions,const int&,void> bmbfo1(&MemberFunctions::f, a, 3);
      |                                                                                               ^
cc1plus: all warnings being treated as errors
```

It could be a false positive or because the reference to the literal creates a temporary object.